### PR TITLE
Make the meshnode privilege configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ meshnode_yaw_amount = 0.017
 meshnode_max_radius = 8
 meshnode_show_in_creative = false
 meshnode_enable_crafting = false
+meshnode_disable_privilege = false
 meshnode_fake_shading = false
 meshnode_autoconf = false
 ```

--- a/api.lua
+++ b/api.lua
@@ -7,6 +7,7 @@ meshnode.config = {
 	max_radius = 8,
 	show_in_creative = false,
 	enable_crafting = false,
+	disable_privilege = false,
 	fake_shading = false,
 	autoconf = false,
 }

--- a/init.lua
+++ b/init.lua
@@ -21,6 +21,7 @@ if is_singleplayer then
 	meshnode.config.max_radius = 16
 	meshnode.config.show_in_creative = true
 	meshnode.config.enable_crafting = true
+	mehsnode.config.disable_privilege = true
 	meshnode.config.fake_shading = true
 	meshnode.config.autoconf = true
 else
@@ -51,7 +52,7 @@ if meshnode.config.show_in_creative == false then
 end
 
 local function has_privilege(name)
-	if is_singleplayer then
+	if meshnode.config.disable_privilege == true then
 		return true
 	end
 	return minetest.check_player_privs(name, {meshnode=true})


### PR DESCRIPTION
I think its useful for the make the `meshnode` privilege configurable on multiplayer setups. In private maps among friends it may be desirable to allow everyone to be able to use meshnodes without the bother of granting the `meshnode` privilege to everyone.

Please let me know if there is anything I could do to improve this, I am new to lua.