### PR TITLE
Be more tolerant agains unknown items in meshnode

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -37,7 +37,7 @@ local function connects_to_group(pos, groups)
 end
 
 local function get_tile_textures(tiles)
-	local textures = table.copy(tiles)
+	local textures = table.copy(tiles or {})
 	for i, v in pairs(textures) do
 		if type(v) == "table" then
 			textures[i] = v.name or "blank.png"


### PR DESCRIPTION
I disabled some mods and a ship produces crash with error 
```
2018-01-10 16:55:16: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'meshnode' in callback luaentity_Activate(): /usr/share/minetest/builtin/common/misc_helpers.lua:590: table index is nil
2018-01-10 16:55:16: ERROR[Main]: stack traceback:
2018-01-10 16:55:16: ERROR[Main]: 	/usr/share/minetest/builtin/common/misc_helpers.lua:590: in function 'copy'
2018-01-10 16:55:16: ERROR[Main]: 	.../games/whynot/mods/tools/meshnode/api.lua:40: in function 'get_tile_textures'
2018-01-10 16:55:16: ERROR[Main]: 	.../games/whynot/mods/tools/meshnode/api.lua:205: in function 'add_entity'
2018-01-10 16:55:16: ERROR[Main]: 	.../games/whynot/mods/tools/meshnode/init.lua:192: in function <.../games/whynot/mods/tools/meshnode/init.lua:160>
```
So this is a quick fix to get the world working again